### PR TITLE
feat(value-date-element): support date range

### DIFF
--- a/packages/value-date-element/README.md
+++ b/packages/value-date-element/README.md
@@ -17,8 +17,8 @@ See example in [workbench.mjs](workbench.mjs)
 
 ```html
 <script type="module">
-  import ValueDateElement from 'https://renoirb.com/esm-modules/value-date-element'
-  customElements.define('value-date', ValueDateElement)
+  import { BaseValueDateElement } from 'https://renoirb.com/esm-modules/value-date-element'
+  customElements.define('value-date', BaseValueDateElement)
 </script>
 ```
 
@@ -57,6 +57,8 @@ Form that allows selecting two dates according to limitations such as only in th
 
 
 ## References
+
+- [@renoirb/context-api **Context API**][renoirb-context-api-readme] as per W3C’s Web Component Community Group ContextAPI protocol
 
 [renoirb-context-api-readme]:
   https://renoirb.com/esm-modules/context-api/README.md

--- a/packages/value-date-element/src/browser/base-element.mjs
+++ b/packages/value-date-element/src/browser/base-element.mjs
@@ -4,7 +4,6 @@ import {
   ContextRequest_DateConversion,
 } from './context-api.mjs'
 
-
 export const STYLE = `
   :host {
     display: inline;
@@ -12,7 +11,6 @@ export const STYLE = `
 `
 
 export class BaseValueDateElement extends HTMLElement {
-
   static get observedAttributes() {
     return ['datetime']
   }
@@ -25,7 +23,8 @@ export class BaseValueDateElement extends HTMLElement {
     const styleElement = new CSSStyleSheet()
     styleElement.replaceSync(STYLE)
     this.shadowRoot.adoptedStyleSheets = [styleElement]
-    this._onDateConversionContextEvent = bindContextResponseHandlerMethodForDateContext(this)
+    this._onDateConversionContextEvent =
+      bindContextResponseHandlerMethodForDateContext(this)
     Reflect.set(this._onDateConversionContextEvent, '__temporary_hack__', this)
     //                                              ^ Yes this is ugly ^
     // To my recollection, the point of this.dispatchEvent() is to tell who emitted the event

--- a/packages/value-date-element/src/browser/context-api.mjs
+++ b/packages/value-date-element/src/browser/context-api.mjs
@@ -17,12 +17,6 @@ export const bindContextResponseHandlerMethodForDateContext = (element) => {
     throw new Error(message)
   }
 
-  const datetime = element.getAttribute('datetime')
-  if (!datetime) {
-    const message = `The host implementation MUST have a datetime attribute. ${errorMessageSuffix}`
-    throw new Error(message)
-  }
-
   /**
    * @param {import('../core/types.ts').DateContextPayload} data
    */

--- a/packages/value-date-element/src/browser/index.mjs
+++ b/packages/value-date-element/src/browser/index.mjs
@@ -1,2 +1,3 @@
 export * from './base-element.mjs'
 export * from './context-api.mjs'
+export * from './date-range-element.mjs'

--- a/packages/value-date-element/src/core/calculate-duration.mjs
+++ b/packages/value-date-element/src/core/calculate-duration.mjs
@@ -1,0 +1,53 @@
+const MILLISECONDS_IN_DAY = 1000 * 60 * 60 * 24
+
+export const calculateDuration = (startDate, endDate) => {
+  // Convert to UTC to avoid timezone/DST issues
+  const [startYear, startMonth] = startDate.split('-').map(Number)
+  const start = Date.UTC(startYear, startMonth - 1, 1)
+
+  const end = endDate
+    ? Date.UTC(
+        ...endDate
+          .split('-')
+          .map(Number)
+          .map((n, i) => (i === 1 ? n - 1 : n)),
+      )
+    : Date.now()
+
+  if (isNaN(start)) {
+    throw new Error('Invalid start date')
+  }
+
+  if (isNaN(end)) {
+    throw new Error('Invalid end date')
+  }
+
+  if (start > end) {
+    throw new Error('Start date must be before end date')
+  }
+
+  // Get total months between dates
+  const totalMonths =
+    (new Date(end).getUTCFullYear() - new Date(start).getUTCFullYear()) * 12 +
+    (new Date(end).getUTCMonth() - new Date(start).getUTCMonth())
+
+  const years = Math.floor(totalMonths / 12)
+  const months = totalMonths % 12
+
+  // Calculate remaining days
+  const yearMonthDate = new Date(
+    Date.UTC(
+      new Date(start).getUTCFullYear() + years,
+      new Date(start).getUTCMonth() + months,
+      new Date(start).getUTCDate(),
+    ),
+  )
+
+  const days = Math.floor((end - yearMonthDate.getTime()) / MILLISECONDS_IN_DAY)
+
+  return {
+    years,
+    months,
+    days,
+  }
+}

--- a/packages/value-date-element/src/core/index.mjs
+++ b/packages/value-date-element/src/core/index.mjs
@@ -1,1 +1,2 @@
+export * from './calculate-duration.mjs'
 export * from './validator.mjs'

--- a/packages/value-date-element/workbench.html
+++ b/packages/value-date-element/workbench.html
@@ -19,8 +19,8 @@
   </head>
   <body>
     <section>
-      <my-component-showcase name="BaseValueDateElement" slots="alpha">
 
+      <my-component-showcase name="BaseValueDateElement" slots="alpha">
         <template slot="alpha" title="Simplest">
           <the-tested-component
             datetime="2025-02-08"

--- a/packages/value-date-element/workbench.mjs
+++ b/packages/value-date-element/workbench.mjs
@@ -7,8 +7,8 @@ import dayjs from 'https://cdn.skypack.dev/dayjs'
 import 'https://cdn.skypack.dev/dayjs/locale/pt'
 import weekday from 'https://cdn.skypack.dev/dayjs/plugin/weekday'
 import customParseFormat from 'https://cdn.skypack.dev/dayjs/plugin/customParseFormat'
-dayjs.extend(weekday);
-dayjs.extend(customParseFormat);
+dayjs.extend(weekday)
+dayjs.extend(customParseFormat)
 
 /**
  * From the client-side, and early in the document, we
@@ -35,4 +35,7 @@ const dateConversionContextResponder = (event) => {
   }
 }
 
-window.document.body.addEventListener('context-request', dateConversionContextResponder)
+window.document.body.addEventListener(
+  'context-request',
+  dateConversionContextResponder,
+)


### PR DESCRIPTION
Other things to do:
- ~~Allow use of `textContent` to pass date string so it is displayed by default if the component isn’t imported~~ (later?)
- Enforce and validate date to be strictly ISO8601 year, month, date (e.g. `YYYY-mm-dd`, such as `2025-02-14`)
- Component to pass two dates and we can know the duration