### PR TITLE
feat(value-date-range): Pass format params to value-date and optionally hide duration text 

### DIFF
--- a/packages/component-showcase-element/src/browser/element.mjs
+++ b/packages/component-showcase-element/src/browser/element.mjs
@@ -78,6 +78,10 @@ export class ComponentShowcaseElement extends HTMLElement {
       this.shadowRoot.querySelector('.title').textContent = name.trim()
     }
 
+    // Validate template[slot] to exist only once for one name.
+    const templateList = [...this.querySelectorAll('template')].map(t => t.getAttribute('slot'))
+    validateSlotsList(templateList.join(' '))
+
     // Validate and normalize slots
     const slots = validateSlotsList(this.getAttribute('slots'))
     const variants = this.shadowRoot.querySelector('.variants')

--- a/packages/context-api/README.md
+++ b/packages/context-api/README.md
@@ -46,6 +46,7 @@ export class SomeExampleElement extends HTMLElement {
       this.dispatchEvent(
         new ContextRequestEvent(
           'date-conversion',
+          this,
           this._onDateConversionContextEvent,
         ),
       )

--- a/packages/context-api/src/browser/event.mjs
+++ b/packages/context-api/src/browser/event.mjs
@@ -29,6 +29,10 @@ export class ContextRequestEvent extends Event {
     subscribe,
   ) {
     super('context-request', { bubbles: true, composed: true })
+    if (!Reflect.has(contextTarget ?? {}, 'getAttribute')) {
+      const message = `Unexpected error, the 2nd ContextRequestEvent constructor argument must be a reference to the current element`
+      throw new Error(message)
+    }
     this.context = context
     this.contextTarget = contextTarget
     this.callback = callback

--- a/packages/value-date-element/src/browser/base-element.mjs
+++ b/packages/value-date-element/src/browser/base-element.mjs
@@ -4,7 +4,7 @@ import {
   ContextRequest_DateConversion,
 } from './context-api.mjs'
 
-export const STYLE = `
+export const BASE_VALUE_ELEMENT_STYLE = `
   :host {
     display: inline;
   }
@@ -21,7 +21,7 @@ export class BaseValueDateElement extends HTMLElement {
     const timeEl = document.createElement('time')
     this.shadowRoot.appendChild(timeEl)
     const styleElement = new CSSStyleSheet()
-    styleElement.replaceSync(STYLE)
+    styleElement.replaceSync(BASE_VALUE_ELEMENT_STYLE)
     this.shadowRoot.adoptedStyleSheets = [styleElement]
     this._onDateConversionContextEvent =
       bindContextResponseHandlerMethodForDateContext(this)

--- a/packages/value-date-element/src/browser/context-api.mjs
+++ b/packages/value-date-element/src/browser/context-api.mjs
@@ -1,9 +1,9 @@
 export const ContextRequest_DateConversion = 'date-conversion'
 
 /**
- * @param {import('./types.ts').DateContextPayload} data
+ * @param {import('./types.ts').DateConversionContextPayload} data
  */
-export const isDateContextPayload = (data) => {
+export const isDateConversionContextPayload = (data) => {
   return (
     data &&
     typeof data === 'object' &&
@@ -14,11 +14,11 @@ export const isDateContextPayload = (data) => {
 }
 
 /**
- * @param {import('./types.ts').DateContextPayload} data
+ * @param {import('./types.ts').DateConversionContextPayload} data
  */
-export const assertIsDateContextPayload = (data) => {
-  if (!isDateContextPayload(data)) {
-    throw new Error('Invalid DateContextPayload')
+export const assertIsDateConversionContextPayload = (data) => {
+  if (!isDateConversionContextPayload(data)) {
+    throw new Error('Invalid DateConversionContextPayload')
   }
 }
 
@@ -41,7 +41,7 @@ export const bindContextResponseHandlerMethodForDateContext = (element) => {
   }
 
   /**
-   * @param {import('./types.ts').DateContextPayload} data
+   * @param {import('./types.ts').DateConversionContextPayload} data
    */
   const handleDateContextResponse = (contextResponse) => {
     const { human, isoString, unixEpoch } = contextResponse

--- a/packages/value-date-element/src/browser/types.ts
+++ b/packages/value-date-element/src/browser/types.ts
@@ -1,4 +1,4 @@
-export interface DateContextPayload {
+export interface DateConversionContextPayload {
   isoString: string
   unixEpoch: string
   human: string

--- a/packages/value-date-element/workbench.html
+++ b/packages/value-date-element/workbench.html
@@ -22,7 +22,8 @@
   <body>
     <section>
 
-      <my-component-showcase name="BaseValueDateElement" slots="alpha bravo">
+      <my-component-showcase name="BaseValueDateElement" slots="alpha bravo charlie delta echo">
+
         <template slot="alpha" title="Simplest">
           <value-date
             datetime="2025-02-08"
@@ -42,9 +43,27 @@
         </template>
 
 
-        <template slot="bravo" title="Only a begin date">
+        <template slot="charlie" title="Only a begin date">
           <value-date-range
             data-date-begin="2024-09-01"
+          >
+          </value-date-range>
+        </template>
+
+        <template slot="delta" title="Hide duration">
+          <value-date-range
+            data-date-begin="2022-05-01"
+            data-range-hide-duration=""
+          >
+          </value-date-range>
+        </template>
+
+
+        <template slot="echo" title="Pass formatting">
+          <value-date-range
+            data-date-begin="2022-05-01"
+            data-date-end="2024-05-01"
+            data-date-format="YYYY"
           >
           </value-date-range>
         </template>

--- a/packages/value-date-element/workbench.mjs
+++ b/packages/value-date-element/workbench.mjs
@@ -1,7 +1,7 @@
 import {
   /*                                  */
   ContextRequest_DateConversion,
-  assertIsDateContextPayload,
+  assertIsDateConversionContextPayload,
 } from 'https://renoirb.com/esm-modules/value-date-element'
 
 import dayjs from 'https://cdn.skypack.dev/dayjs'
@@ -29,7 +29,7 @@ const dateConversionContextResponder = (event) => {
       const isoString = formatter.toISOString()
       const human = formatter.locale(formatLocale).format(format, formatLocale)
       const payload = { date, human, isoString, unixEpoch }
-      assertIsDateContextPayload(payload)
+      assertIsDateConversionContextPayload(payload)
       event.callback(payload)
     }
   }


### PR DESCRIPTION
Fixes:
- Ensure `ContextRequestEvent` tells something's wrong

Changes:
- Allow specifying only years range format
- Instead of `(1 year, 4 months)` text in smaller, make it hidden as a `[title]` attribute

<img width="407" alt="Screenshot 2025-02-26 at 13 36 34" src="https://github.com/user-attachments/assets/8c9a8753-8dbd-4fc5-80d7-e389ec9429ad" />
