### PR TITLE
feat(publishing): Process of publishing to code.renoirb.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,8 @@ fmt: md
 dev-server:
 	deno run --allow-net --allow-read scripts/dev-server.ts
 
+# @TODO Make sure we keep dist/http WITH ALL RELEASES otherwise we will lose because push-dir pushes only what's in dist/
+.PHONY: publish
+publish:
+	npx push-dir --dir=dist/http --branch=published --local-branch-name=main --cleanup
+


### PR DESCRIPTION
Way to publish so that it's accessible as `code.renoirb.com` to be available via HTTP URIs.

- Push any files in `dist/` folder
- Leverage Fastly to proxy and cache what's in `https://renoirb.github.io./renoirb-esm-modules/...` URL

## Expected outcome

- Command to build into `dist/` folder
- Command to do the equivalent or use `push-dir` to a "published" orphan branch

### Testing

The following code should be available

- **Source in normal branch** https://github.com/renoirb/renoirb-esm-modules/blob/published/component-showcase-element%400.1.0/src/browser/element.mjs

- **On GitHub Pages** https://renoirb.github.io./renoirb-esm-modules/component-showcase-element@0.1.0/src/browser/element.mjs
- **Destination** https://code.renoirb.com/component-showcase-element@0.1.0/src/browser/element.mjs