### PR TITLE
feat(workbench-maintenance-utils): Reorganize in a way to be able to work with component that's wrapping workspace

### DIFF
--- a/packages/workbench-maintenance-utils/browser.mjs
+++ b/packages/workbench-maintenance-utils/browser.mjs
@@ -1,0 +1,1 @@
+export * from './src/browser.mjs'

--- a/packages/workbench-maintenance-utils/deno.json
+++ b/packages/workbench-maintenance-utils/deno.json
@@ -2,7 +2,8 @@
   "name": "@renoirb-esm-modules/workbench-maintenance-utils",
   "version": "0.1.0",
   "exports": {
+    "./browser.mjs": "./browser.mjs",
     "./dev-server": "./src/deno/dev-server.ts",
     "./generate-barrels": "./src/deno/generate-barrels.ts"
-  },
+  }
 }

--- a/packages/workbench-maintenance-utils/src/browser.mjs
+++ b/packages/workbench-maintenance-utils/src/browser.mjs
@@ -1,0 +1,1 @@
+export * from './browser/index.mjs'

--- a/packages/workbench-maintenance-utils/src/browser/index.mjs
+++ b/packages/workbench-maintenance-utils/src/browser/index.mjs
@@ -1,0 +1,3 @@
+export * from './style.mjs'
+export * from './nav-element.mjs'
+export * from './init.mjs'

--- a/packages/workbench-maintenance-utils/src/browser/index.mjs
+++ b/packages/workbench-maintenance-utils/src/browser/index.mjs
@@ -1,3 +1,3 @@
-export * from './style.mjs'
-export * from './nav-element.mjs'
 export * from './init.mjs'
+export * from './nav-element.mjs'
+export * from './style.mjs'

--- a/packages/workbench-maintenance-utils/src/browser/init.mjs
+++ b/packages/workbench-maintenance-utils/src/browser/init.mjs
@@ -1,0 +1,13 @@
+import {
+  /*                    */
+  WorkbenchNavElement,
+} from './nav-element.mjs'
+import {
+  /*                    */
+  attachDocumentStyle,
+} from './style.mjs'
+
+export const init = (w /*: Window */) => {
+  w.customElements.define('workbench-nav', WorkbenchNavElement)
+  attachDocumentStyle(w)
+}

--- a/packages/workbench-maintenance-utils/src/browser/nav-element.mjs
+++ b/packages/workbench-maintenance-utils/src/browser/nav-element.mjs
@@ -1,0 +1,98 @@
+const STYLE = `
+  :host {
+    display: block;
+  }
+  :host > nav {
+    margin: 1rem 0;
+    padding: 1rem;
+    background: #f0f0f0;
+    border-radius: 0.5rem;
+  }
+  .ul {
+    padding: 1em;
+    background-color: #e5e5e5;
+    margin-bottom: 1em;
+  }
+  .current {
+    font-weight: bold;
+  }
+`
+
+const TEMPLATE = `
+  <nav>
+    <h3 id="title"></h3>
+    <ul></ul>
+  </nav>
+`
+
+const generateListItems = (
+  /*                    */
+  items,
+  current,
+) => {
+  const out = items
+    .sort()
+    .map(
+      (pkg) =>
+        `<li><a href="/?package=${pkg}" ${
+          pkg === current ? 'class="current"' : ''
+        }>${pkg}</a></li>`,
+    )
+
+  return out
+}
+
+/**
+ * Navigation For Current Workbench Packages
+ *
+ * ```
+ * <div>
+ *   <h3>Available Packages:</h3>
+ *   <ul>
+ *     <li><a href="/?package=inline-note-element" class="current">inline-note-element</a></li>
+ *     <li><a href="/?package=notice-box-element">notice-box-element</a></li>
+ *     <li><a href="/?package=value-date-element">value-date-element</a></li>
+ *     <li><a href="/?package=work-experience-element">work-experience-element</a></li>
+ *   </ul>
+ * </div>
+ * ```
+ */
+export class WorkbenchNavElement extends HTMLElement {
+  static get observedAttributes() {
+    return [
+      /*                 */
+      'data-workbench-current',
+      'data-workbench-list',
+      'data-workbench-title',
+    ]
+  }
+
+  constructor() {
+    super()
+    this.attachShadow({ mode: 'open' })
+    const styleElement = new CSSStyleSheet()
+    styleElement.replaceSync(STYLE)
+    this.shadowRoot.adoptedStyleSheets = [styleElement]
+    const templateElement = document.createElement('template')
+    templateElement.innerHTML = TEMPLATE
+    this.shadowRoot.appendChild(templateElement.content.cloneNode(true))
+  }
+
+  connectedCallback() {
+    const current = this.getAttribute('data-workbench-current')
+    const list = this.getAttribute('data-workbench-list').split(' ')
+    const title =
+      this.getAttribute('data-workbench-title') ?? 'Available Packages'
+    this.shadowRoot.getElementById('title').textContent = title + ':'
+    try {
+      this.#render(list, current)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  #render = (list, current) => {
+    const listItems = generateListItems(list, current)
+    this.shadowRoot.querySelector('ul').innerHTML = listItems.join('\n')
+  }
+}

--- a/packages/workbench-maintenance-utils/src/browser/style.mjs
+++ b/packages/workbench-maintenance-utils/src/browser/style.mjs
@@ -1,0 +1,15 @@
+export const OUTER_WORKBENCH_APP_LAYOUT_STYLE = `
+  body {
+    font-family: system-ui, sans-serif;
+    max-width: 80ch;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    background-color: #fff;
+  }
+`
+
+export const attachDocumentStyle = (w /*: Window */) => {
+  const styleElement = w.document.createElement('style')
+  styleElement.innerText = OUTER_WORKBENCH_APP_LAYOUT_STYLE
+  w.document.head.appendChild(styleElement)
+}

--- a/packages/workbench-maintenance-utils/src/browser/style.mjs
+++ b/packages/workbench-maintenance-utils/src/browser/style.mjs
@@ -1,10 +1,15 @@
 export const OUTER_WORKBENCH_APP_LAYOUT_STYLE = `
   body {
     font-family: system-ui, sans-serif;
+    background-color: #fff;
+  }
+  body:has(> section) {
     max-width: 80ch;
     margin: 2rem auto;
     padding: 0 1rem;
-    background-color: #fff;
+  }
+  body:has(app-layout) {
+    /* Nothing to do here just yet */
   }
 `
 

--- a/packages/workbench-maintenance-utils/src/deno/dev-server.ts
+++ b/packages/workbench-maintenance-utils/src/deno/dev-server.ts
@@ -61,7 +61,7 @@ async function generatePackageList(
   packages: string[],
   currentPackage: string,
 ): string {
-  const links = packages
+  const links = packages.sort()
     .map(
       (pkg) =>
         `<li><a href="/?package=${pkg}" ${
@@ -71,7 +71,6 @@ async function generatePackageList(
     .join('\n')
 
   return `
-    ${STYLESHEET}
     <div class="package-list">
       <h3>Available Packages:</h3>
       <ul>${links}</ul>
@@ -130,6 +129,7 @@ async function handleRequest(
             `<head>\n<script type="importmap">${importMap}</script>\n<script type="module">${options.componentShowcaseScriptAsString}</script>`,
           )
           .replace('<body>', `<body>\n${packageList}`)
+          .replace('</body>', '</body>' + STYLESHEET)
 
         return new Response(modified, {
           headers: { 'content-type': contentType },


### PR DESCRIPTION
This PR extends the workbench functionality to properly support full-page "Application Layout" custom elements - components that manage the entire viewport and provide structural chrome for an application.

## Problem

The current workbench excels at displaying multiple variants of contained components, but struggles with elements designed to:
- Occupy the entire viewport
- Manage global application layout/structure
- Contain navigation in their default slot

## Solution

This implementation should allow the workbench to:

1. Recognize and properly render full-page application layout elements
2. Support the element taking over the entire viewport when needed
3. Maintain workbench navigation within the element's default slot
4. Handle the single-instance nature of these global layout components

