### PR TITLE
feat: context-api attach to document, ?setup, workbench.mjs into example-context-api.mjs

### DIFF
--- a/packages/markdown-content-element/example-context-api.mjs
+++ b/packages/markdown-content-element/example-context-api.mjs
@@ -1,48 +1,66 @@
 import {
   /*                                  */
-  ContextRequest_MarkdownContent,
-} from '@renoirb/markdown-content-element'
+  createMemoizedLoader,
+} from '@renoirb/element-utils'
 
 const VERSION_SHOWDOWN = '2.1.0'
 const IMPORT_DEP_SHOWDOWN = `https://ga.jspm.io/npm:showdown@${VERSION_SHOWDOWN}/dist/showdown.js`
 
-// IIFE that creates a cached parser promise
-export const createParser = (() => {
-  let parserPromise = null
+const loadParser = createMemoizedLoader(
+  IMPORT_DEP_SHOWDOWN,
+  async (module) => {
+    await Promise.resolve()
 
-  return async (opts = {}) => {
-    if (parserPromise === null) {
-      parserPromise = (async () => {
-        const imported = await import(IMPORT_DEP_SHOWDOWN)
-        const showdown = imported?.default
-        const converter = new showdown.Converter({ metadata: true, ...opts })
-        converter.setOption('openLinksInNewWindow', true)
-        return converter
-      })()
-    }
-    return parserPromise
-  }
-})()
+    const showdown = module?.default
+    const converter = new showdown.Converter({ metadata: true })
+    converter.setOption('openLinksInNewWindow', true)
+
+    return showdown
+  },
+)
+
+// Create shared processor for date conversions
+const taskQueue = new ThrottledProcessor({ maxConcurrent: 5 })
 
 export const contextRequestListener = async (event) => {
-  if (event.context !== ContextRequest_MarkdownContent) {
+  if (event.context !== 'markdown-content-context') {
     return
   }
   event.stopPropagation()
-  const host = event.contextTarget
-  const markdown = host.innerHTML
-  const parser = await createParser()
-  const html = parser.makeHtml(markdown)
-  event.callback({ markdown, html })
+
+  let html = ''
+
+  await taskQueue.add(async () => {
+    try {
+      const host = event.contextTarget
+      const markdown = host.innerHTML
+      const parser = await loadParser()
+      html = parser.makeHtml(markdown)
+      event.callback({ markdown, html })
+    } catch (error) {
+      html = `<pre>${error}</pre>`
+      event.callback({ markdown, html })
+    }
+  })
 }
 
-if (window?.document?.body) {
+if (typeof window !== 'undefined') {
   const currentUrl = new URL(import.meta.url)
   const setup = currentUrl.searchParams.has('setup')
   if (setup) {
-    window.document.body.addEventListener(
+    window.document.addEventListener(
       'context-request',
       contextRequestListener,
     )
+    loadParser().catch((error) => {
+      console.warn('Failed to pre-load:', error)
+    })
+    window.addEventListener('unload', () => {
+      window.document.removeEventListener(
+        'context-request',
+        contextRequestListener,
+      )
+      taskQueue.destroy()
+    })
   }
 }

--- a/packages/value-date-element/example-context-api.mjs
+++ b/packages/value-date-element/example-context-api.mjs
@@ -2,18 +2,16 @@ import {
   /*                                  */
   createMemoizedLoader,
   ThrottledProcessor,
- } from '@renoirb/element-utils'
+} from '@renoirb/element-utils'
 import {
   /*                                  */
   ContextRequest_DateConversion,
   assertIsDateConversionContextPayload,
 } from '@renoirb/value-date-element'
 
-
 const loadDayjs = createMemoizedLoader(
   'https://cdn.skypack.dev/dayjs',
   async (module) => {
-
     const dayjs = module.default
 
     // Import and configure plugins in parallel for efficiency
@@ -36,7 +34,7 @@ const loadDayjs = createMemoizedLoader(
     dayjs.extend(customParseFormatPlugin)
 
     return dayjs
-  }
+  },
 )
 
 // Create shared processor for date conversions
@@ -48,9 +46,7 @@ export const contextRequestListener = async (event) => {
   }
   event.stopPropagation()
 
-
   await taskQueue.add(async () => {
-
     const dayjsModule = await loadDayjs()
     const dayjs = dayjsModule.default
 
@@ -65,7 +61,9 @@ export const contextRequestListener = async (event) => {
         const formatter = dayjs(date)
         const unixEpoch = formatter.unix()
         const isoString = formatter.toISOString()
-        const human = formatter.locale(formatLocale).format(format, formatLocale)
+        const human = formatter
+          .locale(formatLocale)
+          .format(format, formatLocale)
         const payload = { date, human, isoString, unixEpoch }
         assertIsDateConversionContextPayload(payload)
         event.callback(payload)
@@ -77,26 +75,25 @@ export const contextRequestListener = async (event) => {
         date,
         human: date,
         isoString: date,
-        unixEpoch: 0
+        unixEpoch: 0,
       })
     }
   })
 }
 
-
-if (window?.document?.body) {
+if (typeof window !== 'undefined') {
   const currentUrl = new URL(import.meta.url)
   const setup = currentUrl.searchParams.has('setup')
   if (setup) {
-    window.document.body.addEventListener(
+    window.document.addEventListener(
       'context-request',
       contextRequestListener,
     )
-    loadDayjs().catch(error => {
+    loadDayjs().catch((error) => {
       console.warn('Failed to pre-load dayjs:', error)
     })
     window.addEventListener('unload', () => {
-      window.document.body.removeEventListener(
+      window.document.removeEventListener(
         'context-request',
         contextRequestListener,
       )


### PR DESCRIPTION
- Rename package’s `workbench.html` sibling file example Context API resolver `workbench.mjs` into something usable publicly as `example-context-api.mjs` we can call with `example-context-api.mjs?setup`
- Attach `addEventListener` to document instead of body
