### PR TITLE
feat: Make use of renoirb-esm-modules from within a Nuxt and replacing some components

### DIFF
--- a/packages/app-layout-element/src/browser/element.mjs
+++ b/packages/app-layout-element/src/browser/element.mjs
@@ -650,8 +650,6 @@ export class AppLayoutAlphaElement extends HTMLElement {
       const message = `Invalid location to use <${this.localName} />, make sure it's a direct descendant of body`
       console.error(message)
       if (this.shadowRoot == null) return
-      this.shadowRoot.innerHTML = `<div style="color: red;">${message}</div>`
-      throw new Error(message)
     }
   }
 

--- a/packages/workbench-maintenance-utils/src/deno/dev-server.ts
+++ b/packages/workbench-maintenance-utils/src/deno/dev-server.ts
@@ -66,6 +66,10 @@ async function handleRequest(
 
   console.log(`Request for: ${filepath}`)
 
+  const devServerResponseHeaders = {
+    'Access-Control-Allow-Origin': '*',
+  }
+
   try {
     const normalizedPath = join(
       projectRoot,
@@ -126,11 +130,19 @@ async function handleRequest(
         }
 
         return new Response(modified, {
-          headers: { 'content-type': contentType },
+          headers: {
+            ...devServerResponseHeaders,
+            'content-type': contentType,
+          },
         })
       }
 
-      return new Response(file, { headers: { 'content-type': contentType } })
+      return new Response(file, {
+        headers: {
+          ...devServerResponseHeaders,
+          'content-type': contentType,
+        }
+      })
     } catch (localError) {
       // If this is an import from our mapped URLs, try to resolve it locally first
       if (filepath.startsWith('/esm-modules/')) {
@@ -162,7 +174,10 @@ async function handleRequest(
           const ext = localPath.substring(localPath.lastIndexOf('.'))
           const contentType = MIME_TYPES[ext] || 'text/plain'
           return new Response(file, {
-            headers: { 'content-type': contentType },
+            headers: {
+              ...devServerResponseHeaders,
+              'content-type': contentType,
+            },
           })
         } catch (mappedError) {
           console.error(


### PR DESCRIPTION
One of the main idea of this project is to have native, no-framework dependent, minimal dependency set of tools and then make use of them in a framework project.

This changeset is to allow working locally on this package and https://github.com/renoirb/site (currently running Nuxt dating from 2020) and to replace elements that are initially written in the Vue+Nuxt project and have them be drop-in replacement

This is meant to work with: renoirb/site#86